### PR TITLE
fix bug with -n

### DIFF
--- a/cmd/carcosa/cli.go
+++ b/cmd/carcosa/cli.go
@@ -33,10 +33,11 @@ type Opts struct {
 	ValueEditor          string   `docopt:"-e"`
 	ValueAuth            []string `docopt:"-a"`
 	FlagNoSync           bool     `docopt:"-n"`
-	FlagNoPush           bool     `docopt:"-n"`
 	FlagSyncFirst        bool     `docopt:"-y"`
 	FlagUseMasterCache   bool     `docopt:"-c"`
 	FlagVerbose          int      `docopt:"-v"`
+
+	noPush bool
 }
 
 type cli struct {
@@ -52,6 +53,10 @@ func (cli *cli) run(opts Opts) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if opts.FlagNoSync {
+		opts.noPush = opts.FlagNoSync
 	}
 
 	switch {
@@ -117,13 +122,13 @@ func (cli *cli) init(opts Opts, auth auth.Auth) error {
 		return err
 	}
 
-	opts.FlagNoPush = true
+	opts.noPush = true
 
 	return cli.sync(opts, auth)
 }
 
 func (cli *cli) sync(opts Opts, auth auth.Auth) error {
-	stats, err := cli.carcosa.Sync(opts.ValueRemote, auth, !opts.FlagNoPush)
+	stats, err := cli.carcosa.Sync(opts.ValueRemote, auth, !opts.noPush)
 	if err != nil {
 		return err
 	}

--- a/cmd/carcosa/vault.go
+++ b/cmd/carcosa/vault.go
@@ -26,6 +26,8 @@ func (vault *vault) Key() ([]byte, error) {
 }
 
 func (vault *vault) Get(token string) ([]byte, error) {
+	log.Debugf("reading master-key file: %s", vault.file(token))
+
 	body, err := ioutil.ReadFile(vault.file(token))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -45,6 +47,8 @@ func (vault *vault) Set(token string, body []byte) error {
 			Describe("path", vault.path).
 			Format(err, "unable to create dir for storing master key cache")
 	}
+
+	log.Debugf("writing master-key file: %s", vault.file(token))
 
 	err = ioutil.WriteFile(vault.file(token), body, 0600)
 	if err != nil {


### PR DESCRIPTION
```
 ∞  cat a.go
package main

import (
        "encoding/json"
        "fmt"

        "github.com/docopt/docopt-go"
)

var (
        version = "[manual build]"
        usage   = "xx " + version + `


Usage:
  xx [options]
  xx -h | --help
  xx --version

Options:
  -n         Do not
  -h --help  Show this screen.
  --version  Show version.
`
)

func main() {
        args, err := docopt.ParseArgs(usage, nil, version)
        if err != nil {
                panic(err)
        }

        var opts struct {
                A bool `docopt:"-n"`
                B bool `docopt:"-n"`
        }
        err = args.Bind(&opts)
        if err != nil {
                panic(err)
        }

        {
                marshaledXXX, _ := json.MarshalIndent(opts, "", "  ")
                fmt.Printf("opts: %s\n", string(marshaledXXX))
        }
}
 ∞  go run a.go -n
opts: {
  "A": false,
  "B": true
}
```